### PR TITLE
Declare Apple platform requirements and fix AndroidManifest dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,6 +43,13 @@ let package = Package(
         .package(
             url: "https://github.com/PureSwift/Bluetooth.git",
             from: "7.2.0"
+        ),
+        // `AndroidManifest` moved out of PureSwift/Android into swift-android-native (Android PR
+        // #40); it must now be depended on directly. The URL and branch must match the ones
+        // PureSwift/Android and skip-android-bridge use, or the identity conflicts.
+        .package(
+            url: "https://github.com/MillerTechnologyPeru/swift-android-native.git",
+            branch: "feature/pureswift"
         )
     ],
     targets: [
@@ -79,7 +86,7 @@ let package = Package(
                 ),
                 .product(
                     name: "AndroidManifest",
-                    package: "Android"
+                    package: "swift-android-native"
                 )
             ],
             exclude: ["swift-java.config"],

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,14 @@ let sdkVersionDefine = SwiftSetting.define("ANDROID_SDK_VERSION_" + sdkVersion.d
 let package = Package(
     name: "AndroidBluetooth",
     platforms: [
-        .macOS(.v15)
+        .macOS(.v15),
+        // Declared to match the Bluetooth/GATT/Socket dependencies. This package only ever builds
+        // for Android, but SwiftPM validates platform requirements across the whole graph, and
+        // leaving these unspecified defaults them to iOS 12 — which conflicts with dependencies
+        // that require iOS 13 and breaks any Apple-platform resolve of a package that includes it.
+        .iOS(.v13),
+        .watchOS(.v6),
+        .tvOS(.v13)
     ],
     products: [
         .library(


### PR DESCRIPTION
Two manifest fixes found while building a downstream app (BluetoothExplorer) that depends on this
package.

## Declare Apple platform requirements

The package declared only `.macOS(.v15)`. SwiftPM defaults unspecified platforms to iOS 12, while
`Bluetooth`, `BluetoothGAP` and `GATT` require iOS 13 — so *any* Apple-platform resolve of a graph
containing this package failed:

```
the library 'AndroidBluetooth' requires ios 12.0, but depends on the product 'Bluetooth'
which requires ios 13.0; consider changing the library 'AndroidBluetooth' to require
ios 13.0 or later, or the product 'Bluetooth' to require ios 12.0 or earlier
```

Now declares `.iOS(.v13), .watchOS(.v6), .tvOS(.v13)` to match. This package only ever builds for
Android, but SwiftPM validates platform requirements across the whole graph regardless of
`.when(platforms:)` conditions on the *usage*, so the declaration has to be present.

## Source `AndroidManifest` from swift-android-native

`AndroidManifest` moved out of PureSwift/Android into `swift-android-native` (Android PR #40), but
this package still requested it from `Android`:

```
error: 'androidbluetooth': product 'AndroidManifest' required by package 'androidbluetooth'
target 'AndroidBluetooth' not found in package 'android'
```

The other four products it takes from `Android` (`AndroidOS`, `AndroidContent`, `AndroidUtil`,
`AndroidApp`) are unaffected; only `AndroidManifest` moved. It now depends on
`swift-android-native` directly, using the same fork and branch that PureSwift/Android and
skip-android-bridge use so the package identity does not conflict.

**Note:** depends on MillerTechnologyPeru/swift-android-native#… (merging current upstream `main`
into `feature/pureswift`), because that branch did not yet export `AndroidManifest`. Merge that
first.
